### PR TITLE
Memory no longer limits node/edge file size in colate_all.py

### DIFF
--- a/frag/network/scripts/colate_all.py
+++ b/frag/network/scripts/colate_all.py
@@ -25,9 +25,12 @@ def do_for_dir(input_dir):
             attrs[line_parts[1]] = line_parts[3]
 
     for f_name in prop_dict:
+
         if LINE_REMINDER:
-            print('%s Processing %s...' % (datetime.now(), f_name))
+            print('%s Processing %s/%s...' %
+                  (input_dir, datetime.now(), f_name))
         line_num = 0
+
         out_f = open(f_name.replace(".txt", ".csv"), "w")
         with open(f_name) as in_f:
             for line in in_f:

--- a/frag/network/scripts/colate_all.py
+++ b/frag/network/scripts/colate_all.py
@@ -27,33 +27,34 @@ def do_for_dir(input_dir):
             print('%s Processing %s...' % (datetime.now(), f_name))
         line_num = 0
         out_f = open(f_name.replace(".txt", ".csv"), "w")
-        for line in open(f_name).readlines():
+        with open(f_name) as in_f:
+            for line in in_f:
 
-            if LINE_REMINDER:
-                # Count the lines, simply to allow us
-                # to allow us to print a re-assuring update...
-                line_num += 1
-                if line_num % LINE_REMINDER == 0:
-                    print('%s ...%d' % (datetime.now(), line_num))
+                if LINE_REMINDER:
+                    # Count the lines, simply to allow us
+                    # to allow us to print a re-assuring update...
+                    line_num += 1
+                    if line_num % LINE_REMINDER == 0:
+                        print('%s ...%d' % (datetime.now(), line_num))
 
-            line_spl = line.split()
-            out_l = []
-            for i, x in enumerate(prop_dict[f_name]):
-                if x:
-                    out_l.append(line_spl[i])
-            if f_name == "nodes.txt":
-                attr_cmp_id = attrs.get(line_spl[1], None)
-                if attr_cmp_id:
-                    cmpd_id = attr_cmp_id
-                    out_l.append(cmpd_id)
-                    # This is where we can add tags - like CHEAP - EXPENSIVE
-                    out_l.append("EM;MOL;F2")
-                else:
-                    out_l.append("")
-                    out_l.append("F2")
-                out_f.write(",".join(out_l) + "\n")
-            elif f_name == "edges.txt":
-                out_f.write(",".join(out_l) + "\n")
+                line_spl = line.split()
+                out_l = []
+                for i, x in enumerate(prop_dict[f_name]):
+                    if x:
+                        out_l.append(line_spl[i])
+                if f_name == "nodes.txt":
+                    attr_cmp_id = attrs.get(line_spl[1], None)
+                    if attr_cmp_id:
+                        cmpd_id = attr_cmp_id
+                        out_l.append(cmpd_id)
+                        # This is where we can add tags - like CHEAP - EXPENSIVE
+                        out_l.append("EM;MOL;F2")
+                    else:
+                        out_l.append("")
+                        out_l.append("F2")
+                    out_f.write(",".join(out_l) + "\n")
+                elif f_name == "edges.txt":
+                    out_f.write(",".join(out_l) + "\n")
 
         if LINE_REMINDER:
             print('%s Processed.' % datetime.now())

--- a/frag/network/scripts/colate_all.py
+++ b/frag/network/scripts/colate_all.py
@@ -31,8 +31,6 @@ def do_for_dir(input_dir):
             for line in in_f:
 
                 if LINE_REMINDER:
-                    # Count the lines, simply to allow us
-                    # to allow us to print a re-assuring update...
                     line_num += 1
                     if line_num % LINE_REMINDER == 0:
                         print('%s ...%d' % (datetime.now(), line_num))
@@ -57,7 +55,7 @@ def do_for_dir(input_dir):
                     out_f.write(",".join(out_l) + "\n")
 
         if LINE_REMINDER:
-            print('%s Processed.' % datetime.now())
+            print('%s Processed (%d)' % (datetime.now(), line_num))
         out_f.flush()
         out_f.close()
 

--- a/frag/network/scripts/colate_all.py
+++ b/frag/network/scripts/colate_all.py
@@ -19,8 +19,10 @@ def do_for_dir(input_dir):
     # build a map of SMILES to chemical ID
     # from the attributes file...
     attrs = {}
-    for x in open("attributes.txt").readlines():
-        attrs[x.split()[1]] = x.split()[3]
+    with open("attributes.txt") as attr_f:
+        for line in attr_f:
+            line_parts = line.split()
+            attrs[line_parts[1]] = line_parts[3]
 
     for f_name in prop_dict:
         if LINE_REMINDER:

--- a/frag/network/scripts/colate_all.py
+++ b/frag/network/scripts/colate_all.py
@@ -28,7 +28,7 @@ def do_for_dir(input_dir):
 
         if LINE_REMINDER:
             print('%s Processing %s/%s...' %
-                  (input_dir, datetime.now(), f_name))
+                  (datetime.now(), input_dir, f_name))
         line_num = 0
 
         out_f = open(f_name.replace(".txt", ".csv"), "w")


### PR DESCRIPTION
An adjustment to the main-loop that avoids loading the input files into memory before they're processed. Instead, the node and edge files are processed line-by-line. The attributes are also processed line by line. Includes a minor adjustment to the stdout. The limiting factor now is memory to hold the `attrs` map.