### PR TITLE
 Neo4j Compound ID change 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ipython==5.4.1
-tqdm
-neo4j-driver
-numpy
-nose
-coveralls
-requests
+tqdm==4.48.2
+neo4j-driver==1.7.6
+numpy==1.19.2
+nose==1.3.7
+coveralls==2.1.1
+requests==2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ tqdm==4.48.2
 neo4j-driver==1.7.6
 numpy>=1.16.6
 nose>=1.3.7
-coveralls>=2.1.1
+coveralls>=1.11.1
 requests>=2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-ipython==5.4.1
+ipython>=5.4.1
 tqdm==4.48.2
 neo4j-driver==1.7.6
-numpy==1.19.2
-nose==1.3.7
-coveralls==2.1.1
-requests==2.24.0
+numpy>=1.19.1
+nose>=1.3.7
+coveralls>=2.1.1
+requests>=2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ipython>=5.4.1
 tqdm==4.48.2
 neo4j-driver==1.7.6
-numpy>=1.19.1
+numpy>=1.16.6
 nose>=1.3.7
 coveralls>=2.1.1
 requests>=2.24.0

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = f.read()
 
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
 
 setup(
     name="fragalysis",
@@ -62,14 +64,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=[
-        "tqdm",
-        "neo4j-driver",
-        "numpy",
-        "nose",
-        "pprint",
-        "socketIO_client_nexus",
-    ],
+    install_requires=required,
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
     # for example:

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="0.5.1",
+    version="0.6.0",
     description="Library for fragment based analysis",
     long_description=long_description,
     # The project's main homepage.


### PR DESCRIPTION
Changes to the Neo4j function get_full_graph to return compound-ids from the Neo4j database so that they can be returned by api/graph in the Fragalysis-backend repo.

Note that these changes must be uploaded to PyPi so they can be installed when the Fragalysis-backend is built.

Fragalysis-backend assumes a fragalysis release version number of 0.6.0 in PyPi (this is in the file setup.py).

See  Fragalysis-backend neo4j-compound-id branch for more details. 
