### PR TITLE
fix(40): guard find_atom_pairs against iso SMILES token mismatch

### DIFF
--- a/fragutils/network/decorate.py
+++ b/fragutils/network/decorate.py
@@ -213,16 +213,14 @@ def find_atom_pairs(smiles_input, get_indices, iso_smiles):
     :return:
     """
     matches = re.findall(XE_PATT, smiles_input)
-    if iso_smiles:
-        iso_matches = re.findall(XE_PATT, iso_smiles)
-    else:
-        iso_matches = None
-        isotope = None
+    iso_matches = re.findall(XE_PATT, iso_smiles) if iso_smiles else []
     ind_list = []
     for i, match in enumerate(matches):
         index = int(match[:-2])
-        if iso_matches:
-            isotope = int(iso_matches[i][:-2])
+        # iso_matches may be shorter than (or misaligned with) matches when the
+        # isomeric SMILES yields fewer [<n>Xe] tokens; fall back to no isotope
+        # rather than raising IndexError (xchem/fragutils#40).
+        isotope = int(iso_matches[i][:-2]) if i < len(iso_matches) else None
         indices = ret_comb_index(index, get_indices, isotope)
         ind_list.append(indices)
     return ind_list

--- a/fragutils/tests/test_network.py
+++ b/fragutils/tests/test_network.py
@@ -16,6 +16,7 @@ from fragutils.network.decorate import (
     deletion_linker_mol,
     deletion_linker_smi,
     del_link_coord,
+    find_atom_pairs,
 )
 
 
@@ -224,6 +225,24 @@ class NetworksTest(unittest.TestCase):
             self.assertTupleEqual(
                 ret_comb_index(get_comb_index(data[0], data[1])), data
             )
+
+    def test_find_atom_pairs_iso_mismatch(self):
+        """
+        find_atom_pairs must not raise when the isomeric SMILES yields fewer
+        [<n>Xe] tokens than the plain SMILES (xchem/fragutils#40). The extra,
+        unmatched positions fall back to isotope=None instead of IndexError.
+        """
+        # smiles_input has two numbered-Xe tokens, iso_smiles only one.
+        res = find_atom_pairs("C[100Xe].C[102Xe]", True, "C[105Xe]")
+        self.assertEqual(len(res), 2)
+        # First position pairs with the single iso token, second falls back.
+        self.assertEqual(res[0][2], 105)
+        self.assertIsNone(res[1][2])
+
+        # Empty iso SMILES previously left `isotope` unbound; ensure it is None.
+        res = find_atom_pairs("C[100Xe].C[102Xe]", True, "")
+        self.assertEqual(len(res), 2)
+        self.assertTrue(all(pair[2] is None for pair in res))
 
     def test_ring_ring_smi(self):
         input_smi = "CC(=O)NC=1C=CC(=CC1)C2=CSC(N)=N2"


### PR DESCRIPTION
Closes #40.

## Problem
`get_vect_indices_for_mol` → `find_atom_pairs` (`fragutils/network/decorate.py:225`) raised `IndexError: list index out of range`, surfacing as a 500 in the fragalysis backend's `VectorsSerializer.get_vectors`.

`find_atom_pairs` extracts `[<n>Xe]` tokens from two independently-canonicalised SMILES — `matches` (plain, position labels via `get_comb_index`) and `iso_matches` (isomeric, `100,101,…` isotope counter). It iterates over `matches` but indexes `iso_matches[i]`, assuming both lists are equal-length and aligned. When the isomeric form yields fewer tokens, `iso_matches[i]` overruns. A non-empty `iso_smiles` that produces zero matches also left `isotope` unbound (latent `NameError`).

## Fix
Always treat `iso_matches` as a list (`[]` when `iso_smiles` is falsy) and bound-check the per-iteration lookup, falling back to `isotope=None` (already tolerated by `ret_comb_index`) when out of range.

## Tests
Added `test_find_atom_pairs_iso_mismatch` in `fragutils/tests/test_network.py` covering the shorter-iso (previously `IndexError`) and empty-iso (previously unbound `isotope`) cases. Full `test_network.py` suite green (10 passed, 1 pre-existing skip).

## Follow-up (out of scope)
The plain vs isomeric fragment lists built by the two `deletion_linker_sd` calls in `del_link_coord` can diverge, so isotopes may still be *misattributed* (rather than crash) when token counts differ. If correct isotope pairing matters downstream, that warrants a separate ticket to align fragments by identity rather than list position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
