### PR TITLE
build(52)!: move to numpy v2.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,8 +24,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - "3.10"
         - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -37,7 +39,7 @@ jobs:
       run: |
         pip install -r build-requirements.txt
         pip install -e .
-        pip install rdkit==2023.3.2
+        pip install rdkit==2025.3.6
     - name: Lint
       run: pre-commit run --all-files
     - name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.15-slim
+FROM python:3.13-slim
 
 USER root
 RUN apt-get --allow-releaseinfo-change update \
@@ -8,7 +8,7 @@ RUN apt-get --allow-releaseinfo-change update \
         libsm6 \
         libxrender1 \
         procps \
-    && pip install rdkit==2023.3.2 \
+    && pip install rdkit==2025.3.6 \
     && git clone https://github.com/rdkit/mmpdb /usr/local/mmpdb \
     && pip install /usr/local/mmpdb
 

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,15 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
     # What does your project relate to?
     keywords="",
+    # numpy 2.3 (see install_requires) needs Python >= 3.11.
+    python_requires=">=3.11",
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=["contrib", "docs", "tests"]),
@@ -47,11 +51,10 @@ setup(
         "neo4j-driver == 4.4.11",
         "ipython > 5.4.1, < 6",
         "tqdm >= 4.65.0, < 5",
-        # March 11th 2026.
-        # To avoid errors with numpy 2.4.3 like this...
-        #   A module that was compiled using NumPy 1.x cannot be run in NumPy 2.4.3 as it may crash.
-        # ...we limit ourselves to numpy v1.x until someone fixes this problem.
-        "numpy >= 1.25, < 2",
+        # numpy 2.x to align with fragalysis-backend (numpy ^2.3).
+        # numpy 2.3 requires Python >= 3.11, so this is a breaking change
+        # released as fragutils v2.x. See issue #52.
+        "numpy >= 2.3, < 3",
         "requests >= 2.31.0, < 3",
     ],
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Fixes #52

Builds fragutils against numpy v2 so it can be consumed as a package by
`fragalysis-backend` (which uses `numpy ^2.3`). This is a breaking change to be
released as **fragutils v2.x**.

## Changes

- **`setup.py`**: bump `numpy` from `>=1.25, <2` to `>=2.3, <3`; add
  `python_requires=">=3.11"` (numpy 2.3 dropped Python 3.10); update the Python
  classifiers (3.11–3.14) and replace the stale numpy-1.x comment.
- **CI (`test.yaml`)**: test on `3.11`, `3.12`, `3.13` and `3.14` (3.13/3.14 are
  the priority targets; the earlier versions are kept for convenience), and bump
  the rdkit pin from `2023.3.2` to `2025.3.6` (which ships numpy-2 compatible
  wheels through Python 3.14 — the original pin forced the numpy-1.x constraint).
- **`Dockerfile`**: move the base image to `python:3.13-slim` and bump the rdkit
  pin to `2025.3.6` to match.

## Verification

- Confirmed `rdkit==2025.3.6` and `numpy >=2.3,<3` both ship `cp313` **and**
  `cp314` manylinux_2_28 wheels (compatible with ubuntu-latest CI and the
  `python:3.13-slim` Docker base).
- The full `unittest` suite (22 tests) passes on Python 3.13 against a clean
  `numpy` + `rdkit==2025.3.6` install — the existing `test_vector.py` exercises
  the numpy code paths and all pass unchanged.

## Notes

- The release version is set from the git tag (`FRAG_VERSION`) at release time,
  so tagging `v2.0.0` (or similar) is all that's needed to publish the v2 line —
  no version constant lives in the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
